### PR TITLE
Add a fully anonymous tracking of visited product pages

### DIFF
--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -4,7 +4,7 @@
   "short_name": "amazon_alts",
   "description": "Find a book or something else in Amazon, et fetch it elswehere !",
   "homepage_url": "https://github.com/adriantombu/amazon-alternatives",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "author": "Adrian Tombu",
   "icons": {
     "48": "assets/icon-48.png",
@@ -42,5 +42,5 @@
       "run_at": "document_end"
     }
   ],
-  "permissions": ["activeTab"]
+  "permissions": ["*://api.amazon-alternatives.com/*", "*://localhost/*", "activeTab"]
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,0 +1,38 @@
+import { Countries } from './helpers/stores'
+
+const API_BASE = 'https://api.amazon-alternatives.com'
+
+export const fetchApi = async (url: string, method: 'GET' | 'POST' = 'GET', body: object = {}) => {
+  let data
+
+  try {
+    const res = await fetch(`${API_BASE}${url}`, {
+      body: JSON.stringify(body),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      method,
+      mode: 'cors',
+    })
+
+    data = await res.json()
+  } catch (err) {
+    console.error(err)
+    return null
+  }
+
+  return data
+}
+
+export const apiVisit = async (host: string) => {
+  let asinNode = document.querySelector('[name="asin"]')
+
+  if (!asinNode) {
+    asinNode = document.getElementById('ASIN')
+  }
+
+  const asin = (asinNode as HTMLInputElement).value
+  const country = host.split('.').pop() || Countries.FR
+
+  await fetchApi('/visits', 'POST', { asin, country })
+}

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -1,7 +1,7 @@
 import puppeteer from 'puppeteer'
 import path from 'path'
 
-jest.setTimeout(30000)
+jest.setTimeout(60000)
 
 let browser: puppeteer.Browser
 let page: puppeteer.Page
@@ -45,17 +45,29 @@ describe('e2e testing', () => {
   })
 
   test('dropdown alternatives should exist on product page', async () => {
-    await page.goto('https://www.amazon.fr/Bullshit-Jobs-David-Graeber/dp/B07BSLN78W', {
+    const urls = [
+      'https://www.amazon.fr/Bullshit-Jobs-David-Graeber/dp/B07BSLN78W',
+      'https://www.amazon.fr/Dell-Ordinateur-Portable-Graphics-Fran%C3%A7ais/dp/B07XDBZ5N9',
+      'https://www.amazon.fr/Multim%C3%A8tre-AoKoZo-Automatique-Electrique-Professionnel/dp/B07XK8XLYC',
+      'https://www.amazon.fr/Beehive-Filter-Electric-Starter-4-stroke/dp/B01M15YVJD',
+      'https://www.amazon.fr/NIVEA-Eau-Rose-Micellulaire-400/dp/B086NHB4SN',
+    ]
+
+    await page.goto('https://www.amazon.fr', {
       waitUntil: 'networkidle2',
     })
-
-    const buyButton = await page.$(buyButtonSelector)
-    expect(buyButton).not.toBe(null)
-
     await page.click('#a-autoid-0') // accepts the cookies
-    await page.hover(buyButtonSelector)
 
-    const dropdown = await page.$(dropdownSelector)
-    expect(dropdown).not.toBe(null)
+    for (const url of urls) {
+      await page.goto(url, { waitUntil: 'networkidle2' })
+
+      const buyButton = await page.$(buyButtonSelector)
+      expect(buyButton).not.toBe(null)
+
+      await page.hover(buyButtonSelector)
+
+      const dropdown = await page.$(dropdownSelector)
+      expect(dropdown).not.toBe(null)
+    }
   })
 })

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,9 +1,10 @@
 import { arrayShuffle } from '@adriantombu/array-shuffle'
 
+import { apiVisit } from './api'
 import { getStores, Category, Website } from './helpers/stores'
 import { getTranslations } from './helpers/i18n'
 
-function main() {
+const main = async () => {
   const host = window.location.hostname
   const category = document?.querySelector('#nav-subnav')?.getAttribute('data-category') as Category
   const search = getSearch(category)
@@ -14,10 +15,12 @@ function main() {
     return
   }
 
+  await apiVisit(host)
+
   attachStores(host, stores)
 }
 
-function getSearch(category: Category): string {
+const getSearch = (category: Category): string => {
   if ([Category.ENGLISH_BOOKS, Category.STRIPBOOKS, Category.BOOKS].includes(category)) {
     const nodes = Array.from(document.querySelectorAll('#detailBullets_feature_div .a-list-item'))
     const isbnNode = nodes.find(node => node.textContent?.includes('ISBN-13'))
@@ -48,7 +51,7 @@ function getSearch(category: Category): string {
   )
 }
 
-function attachStores(host: string, stores: Website[]) {
+const attachStores = (host: string, stores: Website[]) => {
   const translations = getTranslations(host)
   const storeLinks = stores.map(store => `<li><a href="${store.url}" target="_blank">${store.title}</a></li>`)
   const startNode = getStartNode()
@@ -79,7 +82,7 @@ function attachStores(host: string, stores: Website[]) {
   parentNode?.parentNode?.insertBefore(divNode, parentNode)
 }
 
-function getStartNode(): HTMLElement | null {
+const getStartNode = (): HTMLElement | null => {
   let startNode = document.getElementById('add-to-cart-button')
 
   if (!startNode) {
@@ -93,7 +96,7 @@ function getStartNode(): HTMLElement | null {
   return startNode
 }
 
-function setStyle(startNode: HTMLElement | null) {
+const setStyle = (startNode: HTMLElement | null) => {
   if (!startNode) {
     return
   }

--- a/src/helpers/i18n.ts
+++ b/src/helpers/i18n.ts
@@ -1,4 +1,4 @@
-export function getTranslations(host: string): Translation {
+export const getTranslations = (host: string): Translation => {
   const translations = [
     {
       hosts: ['www.amazon.fr'],

--- a/src/helpers/stores.ts
+++ b/src/helpers/stores.ts
@@ -8,7 +8,7 @@ const countries = {
   [Countries.IT]: require('./stores/it').stores,
 }
 
-export function getStores(host: string, category: Category, search: string): Website[] {
+export const getStores = (host: string, category: Category, search: string): Website[] => {
   const websites: Website[] = []
 
   for (const store of getCountryStores(host)) {
@@ -23,7 +23,7 @@ export function getStores(host: string, category: Category, search: string): Web
   return websites
 }
 
-export function getCountryStores(host: string): Store[] {
+export const getCountryStores = (host: string): Store[] => {
   const tld = host.split('.').pop() || Countries.FR
 
   return countries[tld] ? countries[tld] : countries[Countries.FR]


### PR DESCRIPTION
We are only sending the ASIN (the Amazon product ID) and the tld (.fr, .com, ...) to the API. The API will be opensourced in the coming weeks.

Here is the api call https://github.com/adriantombu/amazon-alternatives/blob/api-visit/src/api.ts#L37